### PR TITLE
NFC: FeliCa Protocol Expose Read Block API and Allow Specifying Service

### DIFF
--- a/lib/nfc/protocols/felica/felica_poller.c
+++ b/lib/nfc/protocols/felica/felica_poller.c
@@ -118,7 +118,7 @@ NfcCommand felica_poller_state_handler_auth_internal(FelicaPoller* instance) {
         blocks[1] = FELICA_BLOCK_INDEX_WCNT;
         blocks[2] = FELICA_BLOCK_INDEX_MAC_A;
         FelicaPollerReadCommandResponse* rx_resp;
-        error = felica_poller_read_blocks(instance, sizeof(blocks), blocks, &rx_resp);
+        error = felica_poller_read_blocks(instance, sizeof(blocks), blocks, FELICA_SERVICE_RO_ACCESS, &rx_resp);
         if(error != FelicaErrorNone || rx_resp->SF1 != 0 || rx_resp->SF2 != 0) break;
 
         if(felica_check_mac(
@@ -174,7 +174,7 @@ NfcCommand felica_poller_state_handler_auth_external(FelicaPoller* instance) {
         if(error != FelicaErrorNone || tx_resp->SF1 != 0 || tx_resp->SF2 != 0) break;
 
         FelicaPollerReadCommandResponse* rx_resp;
-        error = felica_poller_read_blocks(instance, 1, blocks, &rx_resp);
+        error = felica_poller_read_blocks(instance, 1, blocks, FELICA_SERVICE_RO_ACCESS, &rx_resp);
         if(error != FelicaErrorNone || rx_resp->SF1 != 0 || rx_resp->SF2 != 0) break;
 
         instance->data->data.fs.state.SF1 = 0;
@@ -203,7 +203,7 @@ NfcCommand felica_poller_state_handler_read_blocks(FelicaPoller* instance) {
     }
 
     FelicaPollerReadCommandResponse* response;
-    FelicaError error = felica_poller_read_blocks(instance, block_count, block_list, &response);
+    FelicaError error = felica_poller_read_blocks(instance, block_count, block_list, FELICA_SERVICE_RO_ACCESS, &response);
     if(error == FelicaErrorNone) {
         block_count = (response->SF1 == 0) ? response->block_count : block_count;
         uint8_t* data_ptr =

--- a/lib/nfc/protocols/felica/felica_poller.h
+++ b/lib/nfc/protocols/felica/felica_poller.h
@@ -56,6 +56,24 @@ typedef struct {
  */
 FelicaError felica_poller_activate(FelicaPoller* instance, FelicaData* data);
 
+/**
+ * @brief Performs felica read operation for blocks provided as parameters
+ * 
+ * @param[in, out] instance pointer to the instance to be used in the transaction.
+ * @param[in] block_count Amount of blocks involved in reading procedure
+ * @param[in] block_numbers Array with block indexes according to felica docs
+ * @param[in] service_code Service code for the read operation
+ * @param[out] response_ptr Pointer to the response structure
+ * @return FelicaErrorNone on success, an error code on failure.
+*/
+FelicaError felica_poller_read_blocks(
+    FelicaPoller* instance,
+    const uint8_t block_count,
+    const uint8_t* const block_numbers,
+    uint16_t service_code,
+    FelicaPollerReadCommandResponse** const response_ptr);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/nfc/protocols/felica/felica_poller_i.c
+++ b/lib/nfc/protocols/felica/felica_poller_i.c
@@ -134,6 +134,7 @@ FelicaError felica_poller_read_blocks(
     FelicaPoller* instance,
     const uint8_t block_count,
     const uint8_t* const block_numbers,
+    uint16_t service_code,
     FelicaPollerReadCommandResponse** const response_ptr) {
     furi_assert(instance);
     furi_assert(block_count <= 4);
@@ -143,7 +144,7 @@ FelicaError felica_poller_read_blocks(
     felica_poller_prepare_tx_buffer(
         instance,
         FELICA_CMD_READ_WITHOUT_ENCRYPTION,
-        FELICA_SERVICE_RO_ACCESS,
+        service_code,
         block_count,
         block_numbers,
         0,

--- a/lib/nfc/protocols/felica/felica_poller_i.h
+++ b/lib/nfc/protocols/felica/felica_poller_i.h
@@ -70,20 +70,6 @@ FelicaError felica_poller_polling(
     const FelicaPollerPollingCommand* cmd,
     FelicaPollerPollingResponse* resp);
 
-/**
- * @brief Performs felica read operation for blocks provided as parameters
- * 
- * @param[in, out] instance pointer to the instance to be used in the transaction.
- * @param[in] block_count Amount of blocks involved in reading procedure
- * @param[in] block_numbers Array with block indexes according to felica docs
- * @param[out] response_ptr Pointer to the response structure
- * @return FelicaErrorNone on success, an error code on failure.
-*/
-FelicaError felica_poller_read_blocks(
-    FelicaPoller* instance,
-    const uint8_t block_count,
-    const uint8_t* const block_numbers,
-    FelicaPollerReadCommandResponse** const response_ptr);
 
 /**
  * @brief Performs felica write operation with data provided as parameters

--- a/targets/f7/api_symbols.csv
+++ b/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,79.2,,
+Version,+,79.3,,
 Header,+,applications/drivers/subghz/cc1101_ext/cc1101_ext_interconnect.h,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/bt/bt_service/bt_keys_storage.h,,
@@ -1047,6 +1047,7 @@ Function,+,felica_get_uid,const uint8_t*,"const FelicaData*, size_t*"
 Function,+,felica_is_equal,_Bool,"const FelicaData*, const FelicaData*"
 Function,+,felica_load,_Bool,"FelicaData*, FlipperFormat*, uint32_t"
 Function,+,felica_poller_activate,FelicaError,"FelicaPoller*, FelicaData*"
+Function,+,felica_poller_read_blocks,FelicaError,"FelicaPoller*, const uint8_t, const uint8_t*, uint16_t, FelicaPollerReadCommandResponse**"
 Function,+,felica_poller_sync_read,FelicaError,"Nfc*, FelicaData*, const FelicaCardKey*"
 Function,+,felica_reset,void,FelicaData*
 Function,+,felica_save,_Bool,"const FelicaData*, FlipperFormat*"
@@ -2938,9 +2939,9 @@ Function,+,pipe_install_as_stdio,void,PipeSide*
 Function,+,pipe_receive,size_t,"PipeSide*, void*, size_t, FuriWait"
 Function,+,pipe_role,PipeRole,PipeSide*
 Function,+,pipe_send,size_t,"PipeSide*, const void*, size_t, FuriWait"
+Function,+,pipe_set_broken_callback,void,"PipeSide*, PipeSideBrokenCallback, FuriEventLoopEvent"
 Function,+,pipe_set_callback_context,void,"PipeSide*, void*"
 Function,+,pipe_set_data_arrived_callback,void,"PipeSide*, PipeSideDataArrivedCallback, FuriEventLoopEvent"
-Function,+,pipe_set_broken_callback,void,"PipeSide*, PipeSideBrokenCallback, FuriEventLoopEvent"
 Function,+,pipe_set_space_freed_callback,void,"PipeSide*, PipeSideSpaceFreedCallback, FuriEventLoopEvent"
 Function,+,pipe_spaces_available,size_t,PipeSide*
 Function,+,pipe_state,PipeState,PipeSide*


### PR DESCRIPTION
# What's new

- See [OFW PR #4074](https://github.com/flipperdevices/flipperzero-firmware/pull/4074) for detail

# Verification 

- External app can use the api to read specified service codes. Example also provided in 4074.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
